### PR TITLE
handle non-string/non-int lookup keys gracefully

### DIFF
--- a/iso3166/__init__.py
+++ b/iso3166/__init__.py
@@ -290,7 +290,7 @@ class _CountryLookup(object):
     def get(self, key, default=NOT_FOUND):
         if isinstance(key, Integral):
             r = _by_numeric.get("%03d" % key, default)
-        else:
+        elif isinstance(key, basestring):
             k = key.upper()
             if len(k) == 2:
                 r = _by_alpha2.get(k, default)
@@ -300,6 +300,8 @@ class _CountryLookup(object):
                 r = _by_alpha3.get(k, default)
             else:
                 r = _by_name.get(k, default)
+        else:
+            r = default
 
         if r == NOT_FOUND:
             raise KeyError(key)

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -25,6 +25,14 @@ def test_length():
     assert len(countries) == len(iso3166._records)
 
 
+def test_empty_string():
+    check_lookup("US", ["us", "US"], [""])
+
+
+def test_none():
+    check_lookup("US", ["us", "US"], [None])
+
+
 def test_alpha2():
     check_lookup("US", ["us", "US"], ["zz"])
 


### PR DESCRIPTION
Currently, a call to `countries.get(None, '')` would throw an `AttributeError` due to the `<key>.upper()` call:

```python
>           k = key.upper()
E           AttributeError: 'NoneType' object has no attribute 'upper'
```
This commit makes this more graceful by following current behaviour to raise a `KeyError` if no default argument is passed in, or return the default. Standard dictionaries support non-string/non-integer key lookups so I think we should too, at least it caught me out.