### PR TITLE
Pass along positional tox arguments into pytest.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27,py34
 
 [testenv]
 deps=pytest
-commands=py.test
+commands=py.test {posargs}


### PR DESCRIPTION
Based on the example at http://tox.readthedocs.org/en/latest/example/pytest.html

This allows me to run `bin/tox tests` and only execute the iso3166 specific tests. Otherwise it runs all tests in the virtualenv incl. setuptools tests for me.

I don't have a global virtualenv or tox installed, but keep those local to each project.