### PR TITLE
Declare PyPi version classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,9 @@ setup(name='iso3166',
           "License :: OSI Approved :: MIT License",
           "Intended Audience :: Developers",
           "Natural Language :: English",
-          "Programming Language :: Python"])
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.4",
+      ])


### PR DESCRIPTION
The list of supported versions matches the environments tested by default in tox.ini.

This allows tools like caniusepython3 or http://caniusepython3.com/ to figure out automatically that this project supports Python 3.