### PR TITLE
Include tests in source distribution for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.txt
 include README.rst
 include CHANGES
+recursive-include tests *.py


### PR DESCRIPTION
Hi,
OpenBSD relies on regression testing for porting, and it would be helpful to have tests available as part of the PyPI tarball.