### PR TITLE
pep-561 - Add py.typed marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     url="http://github.com/deactivated/python-iso3166",
     description="Self-contained ISO 3166-1 country definitions.",
     packages=find_packages(),
+    package_data = {
+        'iso3166': [ 'py.typed' ],
+    },
     long_description=read("README.rst"),
     zip_safe=False,
     python_requires=">= 3.6",


### PR DESCRIPTION
In order to let mypy use the type hints in iso3166 it must include a py.typed marker file. This PR adds this file to the codebase.

See also: https://www.python.org/dev/peps/pep-0561/