### PR TITLE
Remove utf-8 coding headers

### DIFF
--- a/iso3166/__init__.py
+++ b/iso3166/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from typing import Dict, Iterator, NamedTuple, Type, TypeVar, Union, overload
 

--- a/tests/test_listings.py
+++ b/tests/test_listings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import iso3166
 
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from typing import List, Union
 import pytest
 import iso3166


### PR DESCRIPTION
These aren't required on Python 3, since it uses utf-8 by default.