### PR TITLE
Add emoji flag attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,11 @@ Country details
   >>> from iso3166 import countries
   >>>
   >>> countries.get('us')
-  Country(name='United States', alpha2='US', alpha3='USA', numeric='840')
+  Country(name='United States of America', alpha2='US', alpha3='USA', numeric='840', apolitical_name='United States of America', flag='🇺🇸')
   >>> countries.get('ala')
-  Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248')
+  Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248', apolitical_name='Åland Islands', flag='🇦🇽')
   >>> countries.get(8)
-  Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008')
+  Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008', apolitical_name='Albania', flag='🇦🇱'
 
 
 Country lists and indexes
@@ -47,35 +47,35 @@ Country lists and indexes
 
   >>> for c in countries:
          print(c)
-  >>> Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004')
-  Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248')
-  Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008')
-  Country(name='Algeria', alpha2='DZ', alpha3='DZA', numeric='012')
+  >>> Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫')
+  Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248', apolitical_name='Åland Islands', flag='🇦🇽')
+  Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008', apolitical_name='Albania', flag='🇦🇱')
+  Country(name='Algeria', alpha2='DZ', alpha3='DZA', numeric='012', apolitical_name='Algeria', flag='🇩🇿')
 
 ::
 
   >>> import iso3166
 
   >>> iso3166.countries_by_name
-  >>> {'AFGHANISTAN': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004'),
-  'ALBANIA': Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008'),
-  'ALGERIA': Country(name='Algeria', alpha2='DZ', alpha3='DZA', numeric='012'),
+  >>> {'AFGHANISTAN': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫'),
+  'ÅLAND ISLANDS': Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248', apolitical_name='Åland Islands', flag='🇦🇽'),
+  'ALBANIA': Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008', apolitical_name='Albania', flag='🇦🇱'), 'ALGERIA': Country(name='Algeria', alpha2='DZ', alpha3='DZA', numeric='012', apolitical_name='Algeria', flag='🇩🇿'),
   ...
 
   >>> iso3166.countries_by_numeric
-  >>> {'004': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004'),
-  '008': Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008'),
-  '010': Country(name='Antarctica', alpha2='AQ', alpha3='ATA', numeric='010'),
+  >>> {'004': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫'),
+  '008': Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008', apolitical_name='Albania', flag='🇦🇱'),
+  '010': Country(name='Antarctica', alpha2='AQ', alpha3='ATA', numeric='010', apolitical_name='Antarctica', flag='🇦🇶'),
   ...
 
   >>> iso3166.countries_by_alpha2
-  >>> {'AD': Country(name='Andorra', alpha2='AD', alpha3='AND', numeric='020'),
-  'AE': Country(name='United Arab Emirates', alpha2='AE', alpha3='ARE', numeric='784'),
-  'AF': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004'),
+  >>> {'AD': Country(name='Andorra', alpha2='AD', alpha3='AND', numeric='020', apolitical_name='Andorra', flag='🇦🇩'),
+  'AE': Country(name='United Arab Emirates', alpha2='AE', alpha3='ARE', numeric='784', apolitical_name='United Arab Emirates', flag='🇦🇪'),
+  'AF': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫'),
   ...
 
   >>> iso3166.countries_by_alpha3
-  >>> {'ABW': Country(name='Aruba', alpha2='AW', alpha3='ABW', numeric='533'),
-  'AFG': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004'),
-  'AGO': Country(name='Angola', alpha2='AO', alpha3='AGO', numeric='024'),
+  >>> {'ABW': Country(name='Aruba', alpha2='AW', alpha3='ABW', numeric='533', apolitical_name='Aruba', flag='🇦🇼'),
+  'AFG': Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫'),
+  'AGO': Country(name='Angola', alpha2='AO', alpha3='AGO', numeric='024', apolitical_name='Angola', flag='🇦🇴'),
   ...

--- a/src/iso3166/__init__.py
+++ b/src/iso3166/__init__.py
@@ -15,6 +15,7 @@ class Country(NamedTuple):
     alpha3: str
     numeric: str
     apolitical_name: str
+    flag: str = ""
 
 
 _records = [
@@ -449,6 +450,28 @@ _records = [
 ]
 
 
+def _get_flag_emoji(alpha2: str) -> str:
+    """Get the flag emoji for the provided country.
+
+    Args:
+        alpha2 (str): The two-letter ISO code for the country.
+
+    Returns:
+        A string containing the emoji.
+    """
+    assert len(alpha2) == 2
+
+    def _box(ch: str) -> str:
+        return chr(ord(ch) + 0x1F1A5)
+
+    return _box(alpha2[0]) + _box(alpha2[1])
+
+
+_records = [
+    r._replace(flag=_get_flag_emoji(r.alpha2)) for r in _records
+]
+
+
 def _build_index(idx: int) -> Dict[str, Country]:
     return dict((r[idx].upper(), r) for r in _records)
 
@@ -459,6 +482,7 @@ _by_alpha3 = _build_index(2)
 _by_numeric = _build_index(3)
 _by_name = _build_index(0)
 _by_apolitical_name = _build_index(4)
+_by_flag = _build_index(5)
 
 
 # Documented accessors for the country indexes
@@ -467,6 +491,7 @@ countries_by_alpha3 = _by_alpha3
 countries_by_numeric = _by_numeric
 countries_by_name = _by_name
 countries_by_apolitical_name = _by_apolitical_name
+countries_by_flag = _by_flag
 
 
 class NotFound:
@@ -490,8 +515,10 @@ class _CountryLookup:
             r = _by_numeric.get(k, default)
         else:
             k = key.upper()
-            if len(k) == 2:
+            if len(k) == 2 and k in _by_alpha2:
                 r = _by_alpha2.get(k, default)
+            elif len(k) == 2 and k in _by_flag:
+                r = _by_flag.get(k, default)
             elif len(k) == 3 and re.match(r"[0-9]{3}", k) and k != "000":
                 r = _by_numeric.get(k, default)
             elif len(k) == 3:

--- a/tests/test_listings.py
+++ b/tests/test_listings.py
@@ -38,3 +38,9 @@ def test_by_alpha3() -> None:
     table = iso3166.countries_by_alpha3
     assert len(table) >= len(iso3166.countries)
     assert table["AFG"].name == "Afghanistan"
+
+
+def test_by_flag() -> None:
+    table = iso3166.countries_by_flag
+    assert len(table) >= len(iso3166.countries)
+    assert table["🇦🇫"].name == "Afghanistan"

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -42,6 +42,10 @@ def test_alpha3() -> None:
     check_lookup("US", ["usa", "USA"], ["zzz"])
 
 
+def test_flag() -> None:
+    check_lookup("US", ["🇺🇸"], ["zzzz"])
+
+
 def test_name() -> None:
     check_lookup(
         "US",
@@ -82,3 +86,5 @@ def test_data() -> None:
 
         assert len(country.name) > 3
         assert len(country.apolitical_name) > 3
+
+        assert len(country.flag) == 2


### PR DESCRIPTION
This pull request would add a new attribute, `flag`, that returns the emoji associated with each country.

```python
>>> iso3166.countries.get("US").flag
'🇺🇸'
>>> iso3166.countries.get("AFG").flag
'🇦🇫'
>>> list(iso3166.countries_by_flag.items())[:5]
[('🇦🇫', Country(name='Afghanistan', alpha2='AF', alpha3='AFG', numeric='004', apolitical_name='Afghanistan', flag='🇦🇫')), 
 ('🇦🇽', Country(name='Åland Islands', alpha2='AX', alpha3='ALA', numeric='248', apolitical_name='Åland Islands', flag='🇦🇽')),
 ('🇦🇱', Country(name='Albania', alpha2='AL', alpha3='ALB', numeric='008', apolitical_name='Albania', flag='🇦🇱')),
 ('🇩🇿', Country(name='Algeria', alpha2='DZ', alpha3='DZA', numeric='012', apolitical_name='Algeria', flag='🇩🇿')),
 ('🇦🇸', Country(name='American Samoa', alpha2='AS', alpha3='ASM', numeric='016', apolitical_name='American Samoa', flag='🇦🇸'))
]
```

I've included tests and docs. Please let me know what else I could do to improve this request. Thank you for maintaining such a useful library. I believe this patch could make it even handier.