### PR TITLE
Removal of Kosovo according to ISO 3166-1

### DIFF
--- a/src/iso3166/__init__.py
+++ b/src/iso3166/__init__.py
@@ -205,7 +205,6 @@ _records = [
         "Korea, Democratic People's Republic of",
     ),
     Country("Korea, Republic of", "KR", "KOR", "410", "Korea, Republic of"),
-    Country("Kosovo", "XK", "XKX", "983", "Kosovo"),
     Country("Kuwait", "KW", "KWT", "414", "Kuwait"),
     Country("Kyrgyzstan", "KG", "KGZ", "417", "Kyrgyzstan"),
     Country(


### PR DESCRIPTION
Few days back at my work I have noticed that some packages are not aligned with ISO 3166-1. 

According to https://en.wikipedia.org/wiki/XK_(user_assigned_code) and to iso.org official list Kosovo is not on the list of countries ISO 3166-1. It may be added there, but having it among other countries list now is misleading.