### PR TITLE
Proposed script and github actions for checking ISO 3166-1

### DIFF
--- a/.github/workflow/check-remote-iso.yml
+++ b/.github/workflow/check-remote-iso.yml
@@ -1,0 +1,29 @@
+name: Weekly Check of ISO 3166-1
+
+on:
+  schedule:
+    - cron: '0 0 * * MON'
+
+jobs:
+  run_check_script:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    - name: Set up Python environment
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+    
+    - name: Install dependencies
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install -r scripts/requirements.txt
+    
+    - name: Run check.py
+      run: |
+        source .venv/bin/activate
+        python scripts/check.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/_build/
 .tox/
 pyvenv.cfg
 .pytest_cache/
+.venv

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -1,0 +1,27 @@
+import requests
+import sys
+from iso3166 import _records
+
+repository_numeric = []
+for country in _records:
+    repository_numeric.append(country.numeric)
+repository_numeric.sort()
+
+response = requests.get('https://raw.githubusercontent.com/detrin/download-iso3166-list/main/countries.json')
+records_outside = response.json()
+
+outside_numeric = []
+for d in records_outside:
+    outside_numeric.append(d["Numeric"])
+outside_numeric.sort()
+
+extra = set(repository_numeric) - set(outside_numeric)
+if extra:
+    print("Extra in repository: ", extra)
+
+missing = set(outside_numeric) - set(repository_numeric)
+if missing:
+    print("Missing in repository: ", missing)
+
+if extra or missing:
+    sys.exit(1)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
I finished today a CLI tool that can fetch ISO 3166-1 list from iso.org. https://github.com/detrin/download-iso3166-list

I suggest adding this script and github action for regular checks of the list.

I didn't test the github action script, it is only proposed schema.